### PR TITLE
Fix JMH-66: Improve username resolution

### DIFF
--- a/jamh/jira_communicator/src/main/java/cern/enice/jira/amh/jira_rest_communicator/RestOperationsService.java
+++ b/jamh/jira_communicator/src/main/java/cern/enice/jira/amh/jira_rest_communicator/RestOperationsService.java
@@ -80,7 +80,7 @@ public class RestOperationsService {
 			logger.log(LogProvider.DEBUG, "Couldn't fetch issue resolutions.", e);
 		}
 		return null;
-		}
+	}
 	
 	User getUser(String username) {
 		try {
@@ -111,6 +111,12 @@ public class RestOperationsService {
 	Map<String, Object> getUserIfOneIsFound(String username, Object content) {
 		if (username.contains("@")) {
 			List<Map<String, Object>> foundUsers = ((List<Map<String, Object>>) content);
+			// If only one user is found, don't try to match the email to allow users
+			// using their alternative email addresses
+			if (foundUsers.size() == 1) {
+				return foundUsers.get(0);
+			}
+
 			for (Map<String, Object> cUser: foundUsers) {
 				if (((String)cUser.get("emailAddress")).equals(username))
 					return cUser;
@@ -124,7 +130,7 @@ public class RestOperationsService {
 	String getUserSearchUrl(String username) {
 		if (username.contains("@")) 
 			return String.format(
-					"%s/rest/api/latest/user/search?maxResults=0&username=%s", 
+					"%s/rest/api/latest/user/search?maxResults=-1&username=%s", 
 					configuration.getJiraBaseUrl(), username);
 		else 
 			return String.format(

--- a/jamh/jira_communicator/src/main/java/cern/enice/jira/amh/jira_rest_communicator/RestOperationsService.java
+++ b/jamh/jira_communicator/src/main/java/cern/enice/jira/amh/jira_rest_communicator/RestOperationsService.java
@@ -80,7 +80,7 @@ public class RestOperationsService {
 			logger.log(LogProvider.DEBUG, "Couldn't fetch issue resolutions.", e);
 		}
 		return null;
-	}
+		}
 	
 	User getUser(String username) {
 		try {
@@ -111,8 +111,11 @@ public class RestOperationsService {
 	Map<String, Object> getUserIfOneIsFound(String username, Object content) {
 		if (username.contains("@")) {
 			List<Map<String, Object>> foundUsers = ((List<Map<String, Object>>) content);
-			if (foundUsers.isEmpty()) return null;
-			return foundUsers.get(0);
+			for (Map<String, Object> cUser: foundUsers) {
+				if (((String)cUser.get("emailAddress")).equals(username))
+					return cUser;
+			}
+			return null;
 		} else {
 			return (Map<String, Object>)content; 
 		}
@@ -121,7 +124,7 @@ public class RestOperationsService {
 	String getUserSearchUrl(String username) {
 		if (username.contains("@")) 
 			return String.format(
-					"%s/rest/api/latest/user/search?maxResults=1&username=%s", 
+					"%s/rest/api/latest/user/search?maxResults=0&username=%s", 
 					configuration.getJiraBaseUrl(), username);
 		else 
 			return String.format(


### PR DESCRIPTION
This attempts to fix https://open.its.cern.ch/jira/browse/JMH-66 by getting, instead of just the first (and only)  returned result for the username search, all the results and then identifying the right one by comparing the email address.

I haven't tested that. In fact, I don't know if it even compiles (probably not). But I think it is very close to the solution.

Please have a look, and adjust accordingly. I guess this limitation is long due to be fixed, and we should finally get over with it.

Thanks